### PR TITLE
✨ Pull Request: Add Bottom Navigation Bar & Main View

### DIFF
--- a/lib/config/routes/constant_routes.dart
+++ b/lib/config/routes/constant_routes.dart
@@ -1,4 +1,4 @@
 class ConstantRoutes {
   static const String onboarding = '/onboarding';
-  static const String timer = '/timer';
+  static const String pomoMainView = '/pomoMainView';
 }

--- a/lib/config/routes/go_routes.dart
+++ b/lib/config/routes/go_routes.dart
@@ -1,6 +1,6 @@
 import 'package:go_router/go_router.dart';
 import 'package:pomotasks/futures/onborading/presentation/views/onborading_view.dart';
-import 'package:pomotasks/futures/timer/presentation/views/timer_view.dart';
+import 'package:pomotasks/shared/presentation/views/pomo_main_view.dart';
 
 final GoRouter routerHandeler = GoRouter(
   initialLocation: OnboradingView.routeName,
@@ -10,8 +10,8 @@ final GoRouter routerHandeler = GoRouter(
       builder: (context, state) => const OnboradingView(),
     ),
     GoRoute(
-      path: TimerView.routeName,
-      builder: (context, state) => TimerView(),
+      path: PomoMainView.routeName,
+      builder: (context, state) => const PomoMainView(),
     ),
   ],
 );

--- a/lib/config/themes/assets/constant_icons_path.dart
+++ b/lib/config/themes/assets/constant_icons_path.dart
@@ -1,5 +1,4 @@
 class ConstantIconsPath {
   static const String path = "assets/icons/";
-  static const String closeIcon = "${path}cancel.png";
   static const String closeIconSvg = "${path}cancel.svg";
 }

--- a/lib/config/themes/colors/app_colors.dart
+++ b/lib/config/themes/colors/app_colors.dart
@@ -7,4 +7,5 @@ class AppColors {
   static const Color primaryColorBackground = Color(0xFFFCF7F7);
   static const Color textPrimaryColor = Color(0xFF171212);
   static const Color boxsPrimaryColor = Color(0xFFF2E8E8);
+  static const Color boxsStroke = Color(0xFFF2E8E8);
 }

--- a/lib/futures/analytics/presentation/view/analytics_main_view.dart
+++ b/lib/futures/analytics/presentation/view/analytics_main_view.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class AnalyticsMainView extends StatelessWidget {
+  const AnalyticsMainView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: Text("Analytics"));
+  }
+}

--- a/lib/futures/onborading/presentation/functions/get_started.dart
+++ b/lib/futures/onborading/presentation/functions/get_started.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
-import 'package:pomotasks/futures/timer/presentation/views/timer_view.dart';
+import 'package:pomotasks/shared/presentation/views/pomo_main_view.dart';
 
 void getStarted(BuildContext context) {
-  context.go(TimerView.routeName);
+  context.go(PomoMainView.routeName);
 }

--- a/lib/futures/tasks/presentation/view/tasks_main_view.dart
+++ b/lib/futures/tasks/presentation/view/tasks_main_view.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class TasksMainView extends StatelessWidget {
+  const TasksMainView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: Text("Tasks"));
+  }
+}

--- a/lib/futures/timer/presentation/views/timer_view.dart
+++ b/lib/futures/timer/presentation/views/timer_view.dart
@@ -1,11 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:pomotasks/config/routes/constant_routes.dart';
 import 'package:pomotasks/futures/timer/presentation/functions/close.dart';
 import 'package:pomotasks/futures/timer/presentation/widgets/timer_app_bar.dart';
 import 'package:pomotasks/futures/timer/presentation/widgets/timer_clock.dart';
 
 class TimerView extends StatelessWidget {
-  static String routeName = ConstantRoutes.timer;
   const TimerView({super.key});
 
   @override

--- a/lib/futures/timer/presentation/widgets/timer_clock.dart
+++ b/lib/futures/timer/presentation/widgets/timer_clock.dart
@@ -21,38 +21,31 @@ class _TimerClockState extends State<TimerClock> {
   int seconds = ConstantValue.defaultSeconds;
   @override
   Widget build(BuildContext context) {
-    return BlocProvider(
-      create: (context) => TimerCubit(),
-      child: Builder(
-        builder: (context) {
-          return BlocListener<TimerCubit, TimerState>(
-            listener: (context, state) {
-              if (state is TimerChanged) {
-                minutes = state.minutes;
-                seconds = state.seconds;
-                setState(() {});
-              }
-              if (state is TimerReset) {
-                minutes = state.minutes;
-                seconds = state.seconds;
-                setState(() {});
-              }
-            },
-            child: Padding(
-              padding: EdgeInsets.symmetric(vertical: 24.h),
-              child: Column(
-                children: [
-                  TimerItmesViwe(minutes: minutes, seconds: seconds),
-                  TimerClockControls(
-                    startTimer: () => startTimer(context, minutes, seconds),
-                    pauseTimer: () => pauseTimer(context),
-                    restTimer: () => restTimer(context),
-                  ),
-                ],
-              ),
+    return BlocListener<TimerCubit, TimerState>(
+      listener: (context, state) {
+        if (state is TimerChanged) {
+          minutes = state.minutes;
+          seconds = state.seconds;
+          setState(() {});
+        }
+        if (state is TimerReset) {
+          minutes = state.minutes;
+          seconds = state.seconds;
+          setState(() {});
+        }
+      },
+      child: Padding(
+        padding: EdgeInsets.symmetric(vertical: 24.h),
+        child: Column(
+          children: [
+            TimerItmesViwe(minutes: minutes, seconds: seconds),
+            TimerClockControls(
+              startTimer: () => startTimer(context, minutes, seconds),
+              pauseTimer: () => pauseTimer(context),
+              restTimer: () => restTimer(context),
             ),
-          );
-        },
+          ],
+        ),
       ),
     );
   }

--- a/lib/shared/presentation/values/screens/app_screens_list.dart
+++ b/lib/shared/presentation/values/screens/app_screens_list.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/widgets.dart';
+import 'package:pomotasks/futures/analytics/presentation/view/analytics_main_view.dart';
+import 'package:pomotasks/futures/tasks/presentation/view/tasks_main_view.dart';
+import 'package:pomotasks/futures/timer/presentation/views/timer_view.dart';
+
+List<Widget> screens = [
+  TimerView(),
+  TasksMainView(),
+  AnalyticsMainView(),
+];

--- a/lib/shared/presentation/values/texts/texts_values.dart
+++ b/lib/shared/presentation/values/texts/texts_values.dart
@@ -1,0 +1,5 @@
+class ConstantsTextsValues {
+  static const String pomodoro = 'Pomodoro';
+  static const String tasks = 'Tasks';
+  static const String analytics = 'Analytics';
+}

--- a/lib/shared/presentation/views/pomo_main_view.dart
+++ b/lib/shared/presentation/views/pomo_main_view.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:pomotasks/config/routes/constant_routes.dart';
+import 'package:pomotasks/futures/timer/presentation/cubit/timer_cubit.dart';
+import 'package:pomotasks/shared/presentation/values/screens/app_screens_list.dart';
+import 'package:pomotasks/shared/presentation/widgets/pomo_navigation_bar.dart';
+
+class PomoMainView extends StatefulWidget {
+  static const String routeName = ConstantRoutes.pomoMainView;
+  const PomoMainView({super.key});
+
+  @override
+  State<PomoMainView> createState() => _PomoMainViewState();
+}
+
+class _PomoMainViewState extends State<PomoMainView> {
+  int selectedIndex = 0;
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => TimerCubit(),
+      child: Scaffold(
+        bottomNavigationBar: PomoNavigationBar(
+          currentIndex: selectedIndex,
+          onTap: (index) {
+            setState(() {
+              selectedIndex = index;
+            });
+          },
+        ),
+        body: SafeArea(child: screens[selectedIndex]),
+      ),
+    );
+  }
+}

--- a/lib/shared/presentation/widgets/pomo_navigation_bar.dart
+++ b/lib/shared/presentation/widgets/pomo_navigation_bar.dart
@@ -1,0 +1,50 @@
+
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:pomotasks/config/themes/colors/app_colors.dart';
+import 'package:pomotasks/shared/presentation/values/texts/texts_values.dart';
+import 'package:salomon_bottom_bar/salomon_bottom_bar.dart';
+
+class PomoNavigationBar extends StatelessWidget {
+  final int currentIndex;
+  final Function(int) onTap;
+  const PomoNavigationBar({
+    super.key,
+    required this.currentIndex,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.primaryColorBackground,
+        border: Border.all(color: AppColors.boxsStroke),
+      ),
+      child: SalomonBottomBar(
+        currentIndex: currentIndex,
+        onTap: onTap,
+        items: [
+          SalomonBottomBarItem(
+            icon: Icon(Icons.timer, size: 24.sp),
+            title: const Text(ConstantsTextsValues.pomodoro),
+            unselectedColor: AppColors.textPrimaryColor,
+            selectedColor: AppColors.primaryColor,
+          ),
+          SalomonBottomBarItem(
+            icon: Icon(Icons.task, size: 24.sp),
+            title: const Text(ConstantsTextsValues.tasks),
+            unselectedColor: AppColors.textPrimaryColor,
+            selectedColor: AppColors.primaryColor,
+          ),
+          SalomonBottomBarItem(
+            icon: Icon(Icons.analytics, size: 24.sp),
+            title: const Text(ConstantsTextsValues.analytics),
+            unselectedColor: AppColors.textPrimaryColor,
+            selectedColor: AppColors.primaryColor,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -435,6 +435,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.6.3"
+  salomon_bottom_bar:
+    dependency: "direct main"
+    description:
+      name: salomon_bottom_bar
+      sha256: e20abf2e449749432223a8b4e6647c212eef6c2b638e0ed8cc92eff9529c2b48
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.2"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.2
+version: 1.1.3
 
 environment:
   sdk: ^3.8.0
@@ -39,6 +39,7 @@ dependencies:
   go_router: ^15.1.3
   google_fonts: ^6.2.1
   rename_app: ^1.6.3
+  salomon_bottom_bar: ^3.3.2
   time: ^2.1.5
 dev_dependencies:
   flutter_launcher_icons: "^0.14.3"


### PR DESCRIPTION
# ✨ Pull Request: Add Bottom Navigation Bar & Main View

## 📝 Summary

This pull request introduces the following changes:

- ➕ **Bottom Navigation Bar Widget:**  
  - Added a custom bottom navigation bar using the `salomon_bottom_bar` package for a modern look and feel.
  - Navigation bar includes three tabs: Pomodoro, Tasks, and Analytics, each with its own icon and label.

- 🗂️ **Screen Management:**  
  - Created a constant list of main app screens (`app_screens_list.dart`) to manage navigation between Timer, Tasks, and Analytics views.

- 🏷️ **Constants Storage:**  
  - Added a dedicated file for storing constant text values (`texts_values.dart`) to ensure consistency and easy updates for tab labels.

- 🖥️ **Main View Implementation:**  
  - Implemented `PomoMainView`, a stateful widget that manages the selected tab and displays the corresponding screen.
  - Integrated `TimerCubit` using BlocProvider for state management in the main view.

## 📂 Files Added

- `lib/shared/presentation/values/screens/app_screens_list.dart`  
  _Defines the list of main screens for navigation._

- `lib/shared/presentation/values/texts/texts_values.dart`  
  _Stores constant text values for tab labels._

- `lib/shared/presentation/views/pomo_main_view.dart`  
  _Implements the main view with bottom navigation and screen switching logic._

- `lib/shared/presentation/widgets/pomo_navigation_bar.dart`  
  _Custom bottom navigation bar widget using SalomonBottomBar._

## 🗒️ Notes

- The navigation bar provides a user-friendly way to switch between the main features of the app.
- All constant values and screens are now managed in dedicated files for better maintainability.
- Please review the navigation logic and UI for feedback or suggestions.